### PR TITLE
Kubernetes volumes

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -12,6 +12,15 @@ spec:
     volumeMounts:
     - name: app
       mountPath: /app
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 80
+    livenessProbe:
+      tcpSocket:
+        port: 8000
+      initialDelaySeconds: 10
+      periodSeconds: 20
 
   initContainers:
   - name: init-web

--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,315 @@
+# Выполнено ДЗ № 4
+
+ - [X] Основное ДЗ
+ - [ ] Задание со *
+ 
+## В процессе сделано:
+
+Из ДЗ №1 в манифест web-pod.yaml добавили в описание пода readinessProbe с ошибкой номера порта, в итоге под не запустился
+
+```
+Warning  Unhealthy  32s   kubelet, minikube  Readiness probe failed: Get http://172.17.0.6:80/index.html: dial tcp 172.17.0.6:80:connect: connection refused
+```
+
+Добавили проверку livenessProbe, т.к. readinessProbe у нас с ошибкой проверки порта, то по условиям livenessProbe pod будет перезапускаться постоянно пытаясь пройти проверку readinessProbe.
+
+```
+Events:
+  Type     Reason     Age               From               Message
+  ----     ------     ----              ----               -------
+  Normal   Scheduled  44s               default-scheduler  Successfully assigned default/web to minikube
+  Normal   Pulling    43s               kubelet, minikube  Pulling image "busybox:1.31.0"
+  Normal   Pulled     40s               kubelet, minikube  Successfully pulled image "busybox:1.31.0"
+  Normal   Created    40s               kubelet, minikube  Created container init-web
+  Normal   Started    39s               kubelet, minikube  Started container init-web
+  Normal   Pulling    38s               kubelet, minikube  Pulling image "doubllew/public1:web-v2"
+  Normal   Pulled     33s               kubelet, minikube  Successfully pulled image "doubllew/public1:web-v2"
+  Normal   Created    33s               kubelet, minikube  Created container web
+  Normal   Started    32s               kubelet, minikube  Started container web
+  Warning  Unhealthy  2s (x4 over 32s)  kubelet, minikube  Readiness probe failed: Get http://172.17.0.6:80/index.html: dial tcp 172.17.0.6:80: connect: connection refused
+
+NAME   READY   STATUS    RESTARTS   AGE
+web    0/1     Running   0          2m4s
+
+```
+
+#Вопрос для самопроверки:
+
+1. В данном контексте вэб сервис или иной сервис может работать, но pod не принимает соединения и не обрабатывает запросы
+2. Ситуации когда такая проверка имеет смысл, может возникнуть когда проверяемый сервис падает и происходит перезапуск pod
+
+#Создание Deployment
+Создали новый манифест Deployment, перекопировали блок конфигурации из web-deploy.yaml с ошибкой readinessProbe. В итоге после деплоя под не запустился и в условии появилась ошибка
+
+```
+Conditions:
+  Type           Status  Reason
+  ----           ------  ------
+  Available      False   MinimumReplicasUnavailable
+  Progressing    True    ReplicaSetUpdated
+```
+
+Исправили ошибку readinessProbe и увеличили число реплик до 3. В итоге новый манифест деплоя заменил старый и условия выполняются
+
+```
+Conditions:
+  Type           Status  Reason
+  ----           ------  ------
+  Available      True    MinimumReplicasAvailable
+  Progressing    True    NewReplicaSetAvailable
+
+NAME   READY   UP-TO-DATE   AVAILABLE   AGE
+web    3/3     3            3           6m50s
+```
+
+#Создание Deployment. Самостоятельная работа
+
+Добавили блок RollingUpdate в манифест web-deploy.yaml
+
+maxUnavailable: 0
+maxSurge: 0
+```
+The Deployment "web" is invalid: spec.strategy.rollingUpdate.maxUnavailable: Invalid value: intstr.IntOrString{Type:0, IntVal:0, StrVal:""}: may not be 0 when `maxSurge` is 0
+```
+
+maxUnavailable: 100%
+maxSurge: 100%
+```
+0s          Normal    ScalingReplicaSet   deployment/web              Scaled up replica set web-6d5556764d to 3
+0s          Normal    SuccessfulCreate    replicaset/web-6d5556764d   Created pod: web-6d5556764d-wxx9s
+0s          Normal    SuccessfulCreate    replicaset/web-6d5556764d   Created pod: web-6d5556764d-4xw5h
+0s          Normal    Scheduled           pod/web-6d5556764d-4xw5h    Successfully assigned default/web-6d5556764d-4xw5h to minikube
+0s          Normal    SuccessfulCreate    replicaset/web-6d5556764d   Created pod: web-6d5556764d-q82pz
+0s          Normal    Scheduled           pod/web-6d5556764d-wxx9s    Successfully assigned default/web-6d5556764d-wxx9s to minikube
+0s          Normal    Scheduled           pod/web-6d5556764d-q82pz    Successfully assigned default/web-6d5556764d-q82pz to minikube
+0s          Normal    Pulled              pod/web-6d5556764d-wxx9s    Container image "busybox:1.31.0" already present on machine
+0s          Normal    Pulled              pod/web-6d5556764d-4xw5h    Container image "busybox:1.31.0" already present on machine
+0s          Normal    Pulled              pod/web-6d5556764d-q82pz    Container image "busybox:1.31.0" already present on machine
+0s          Normal    Created             pod/web-6d5556764d-wxx9s    Created container init-web
+0s          Normal    Created             pod/web-6d5556764d-4xw5h    Created container init-web
+0s          Normal    Created             pod/web-6d5556764d-q82pz    Created container init-web
+0s          Normal    Started             pod/web-6d5556764d-wxx9s    Started container init-web
+0s          Normal    Started             pod/web-6d5556764d-q82pz    Started container init-web
+0s          Normal    Started             pod/web-6d5556764d-4xw5h    Started container init-web
+0s          Normal    Pulled              pod/web-6d5556764d-4xw5h    Container image "doubllew/public1:web-v2" already present on machine
+0s          Normal    Pulled              pod/web-6d5556764d-q82pz    Container image "doubllew/public1:web-v2" already present on machine
+0s          Normal    Pulled              pod/web-6d5556764d-wxx9s    Container image "doubllew/public1:web-v2" already present on machine
+0s          Normal    Created             pod/web-6d5556764d-4xw5h    Created container web
+0s          Normal    Created             pod/web-6d5556764d-wxx9s    Created container web
+0s          Normal    Created             pod/web-6d5556764d-q82pz    Created container web
+0s          Normal    Started             pod/web-6d5556764d-4xw5h    Started container web
+0s          Normal    Started             pod/web-6d5556764d-q82pz    Started container web
+0s          Normal    Started             pod/web-6d5556764d-wxx9s    Started container web
+
+```
+
+#Создание Service || ClusterIP
+Создали манифест web-svc-cip.yaml где описали доступ к pod по 80 порту и применили его
+```
+kubectl get services
+NAME          TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)   AGE
+kubernetes    ClusterIP   10.96.0.1     <none>        443/TCP   137m
+web-svc-cip   ClusterIP   10.96.13.17   <none>        80/TCP    4m51s
+
+$ minikube ssh
+$ curl http://10.96.13.17/index.html -Ivvv
+> HEAD /index.html HTTP/1.1
+> Host: 10.96.13.17
+> User-Agent: curl/7.66.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+HTTP/1.1 200 OK
+```
+
+В таблице arp и addr не отображается CLUSTER-IP
+```
+$ sudo iptables --list -nv -t nat
+Chain KUBE-SERVICES
+    1    60 KUBE-SVC-WKCOG6KH24K26XRJ  tcp  --  *      *       0.0.0.0/0            10.96.13.17          /* default/web-svc-cip: cluster IP */ tcp dpt:80
+
+Chain KUBE-SVC-WKCOG6KH24K26XRJ (1 references)
+ pkts bytes target     prot opt in     out     source               destination         
+    0     0 KUBE-SEP-4EHRVUY3IKVUBA4M  all  --  *      *       0.0.0.0/0            0.0.0.0/0            statistic mode random probability 0.33333333349
+    0     0 KUBE-SEP-S353CMO5VXPY3Z3E  all  --  *      *       0.0.0.0/0            0.0.0.0/0            statistic mode random probability 0.50000000000
+```
+
+#Включение IPVS
+Отредактировали конфигурационный файл kube-proxy, применили настройки, проверили цепочку iptables.
+Почистили правила iptables в самой ВМ minikube, посмотрели результат
+```
+[root@minikube ~]# ipvsadm --list -n
+TCP  10.96.13.17:80 rr
+  -> 172.17.0.4:8000              Masq    1      0          0         
+  -> 172.17.0.5:8000              Masq    1      0          0         
+  -> 172.17.0.6:8000              Masq    1      0          0
+```
+И ping проходит до нашего pod
+```
+ip addr show kube-ipvs0
+56: kube-ipvs0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN group default 
+    link/ether 9e:ec:f8:2b:c1:e3 brd ff:ff:ff:ff:ff:ff
+...
+    inet 10.96.13.17/32 brd 10.96.13.17 scope global kube-ipvs0
+       valid_lft forever preferred_lft forever
+```
+
+
+# Установка MetalLB
+Устанавливаем из манифеста (на официальном сайте есть обновленный манифест), настроили балансировщик создав манифест metallb-config.yaml (в д/з ошибка, addresses не нужно брать в кавычки иначе не поднимется LoadBalancer) и применяем.
+Создаем манифест web-svc-lb.yaml (в описании д/з ошибка, type должен находится в блоке spec) и применяем, смотрим результат.
+```
+$ kubectl describe svc web-svc-lb 
+Name:                     web-svc-lb
+Namespace:                default
+Labels:                   <none>
+Annotations:              kubectl.kubernetes.io/last-applied-configuration:
+                            {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"web-svc-lb","namespace":"default"},"spec":{"ports":[{"port":80,"p...
+Selector:                 app=web
+Type:                     LoadBalancer
+IP:                       10.96.252.212
+LoadBalancer Ingress:     172.17.255.1
+Port:                     <unset>  80/TCP
+TargetPort:               8000/TCP
+NodePort:                 <unset>  30903/TCP
+Endpoints:                172.17.0.4:8000,172.17.0.5:8000,172.17.0.6:8000
+Session Affinity:         None
+External Traffic Policy:  Cluster
+Events:
+  Type    Reason        Age   From                Message
+  ----    ------        ----  ----                -------
+  Normal  IPAllocated   110s  metallb-controller  Assigned IP "172.17.255.1"
+  Normal  nodeAssigned  110s  metallb-speaker     announcing from node "minikube"
+```
+Добавим статический маршрут из нашего хоста к балансировщику.
+```
+curl http://172.17.255.1/ -Iv
+*   Trying 172.17.255.1...
+* TCP_NODELAY set
+* Connected to 172.17.255.1 (172.17.255.1) port 80 (#0)
+> HEAD / HTTP/1.1
+> Host: 172.17.255.1
+> User-Agent: curl/7.58.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+HTTP/1.1 200 OK
+```
+
+#Создание Ingress
+Устанавливаем манифест из репозитория kubernetes и применяем.
+Создаем манифест с LoadBalancer для ingress-nginx и применяем.
+Проверяем работу сервиса
+```
+kubectl describe -f nginx-lb.yaml 
+Name:                     ingress-nginx
+Namespace:                ingress-nginx
+Labels:                   app.kubernetes.io/name=ingress-nginx
+                          app.kubernetes.io/part-of=ingress-nginx
+Annotations:              kubectl.kubernetes.io/last-applied-configuration:
+                            {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"labels":{"app.kubernetes.io/name":"ingress-nginx","app.kubernetes.io/par...
+Selector:                 app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx
+Type:                     LoadBalancer
+IP:                       10.96.145.128
+LoadBalancer Ingress:     172.17.255.2
+Port:                     http  80/TCP
+TargetPort:               http/TCP
+NodePort:                 http  32527/TCP
+Endpoints:                172.17.0.10:80
+Port:                     https  443/TCP
+TargetPort:               https/TCP
+NodePort:                 https  30522/TCP
+Endpoints:                172.17.0.10:443
+Session Affinity:         None
+External Traffic Policy:  Local
+HealthCheck NodePort:     30831
+Events:
+  Type    Reason        Age                From                Message
+  ----    ------        ----               ----                -------
+  Normal  IPAllocated   22m                metallb-controller  Assigned IP "172.17.255.2"
+  Normal  nodeAssigned  14m (x3 over 22m)  metallb-speaker     announcing from node "minikube"
+  
+ping 172.17.255.2
+PING 172.17.255.2 (172.17.255.2) 56(84) bytes of data.
+64 bytes from 172.17.255.2: icmp_seq=1 ttl=64 time=0.495 ms
+64 bytes from 172.17.255.2: icmp_seq=2 ttl=64 time=2.03 ms
+
+curl http://172.17.255.2 -Iv
+* Rebuilt URL to: http://172.17.255.2/
+*   Trying 172.17.255.2...
+* TCP_NODELAY set
+* Connected to 172.17.255.2 (172.17.255.2) port 80 (#0)
+> HEAD / HTTP/1.1
+> Host: 172.17.255.2
+> User-Agent: curl/7.58.0
+> Accept: */*
+> 
+< HTTP/1.1 404 Not Found
+HTTP/1.1 404 Not Found
+```
+
+#Подключение приложение Web к Ingress
+Создаем манифест с сервисом web-svc без ip адреса и применяем его
+```
+kubectl describe -f web-svc-headless.yaml 
+Name:              web-svc
+Namespace:         default
+Labels:            <none>
+Annotations:       kubectl.kubernetes.io/last-applied-configuration:
+                     {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"web-svc","namespace":"default"},"spec":{"clusterIP":"None","ports...
+Selector:          app=web
+Type:              ClusterIP
+IP:                None
+Port:              <unset>  80/TCP
+TargetPort:        8000/TCP
+Endpoints:         172.17.0.6:8000,172.17.0.7:8000,172.17.0.8:8000
+Session Affinity:  None
+Events:            <none>
+```
+Создаем манифест с правилом по которому ingress будет отрабатывать и применяем.
+```
+kubectl describe -f web-ingress.yaml 
+Name:             web
+Namespace:        default
+Address:          172.17.255.2
+Default backend:  default-http-backend:80 (<none>)
+Rules:
+  Host  Path  Backends
+  ----  ----  --------
+  *     
+        /web   web-svc:8000 (172.17.0.6:8000,172.17.0.7:8000,172.17.0.8:8000)
+Annotations:
+  kubectl.kubernetes.io/last-applied-configuration:  {"apiVersion":"networking.k8s.io/v1beta1","kind":"Ingress","metadata":{"annotations":{"nginx.ingress.kubernetes.io/rewrite-target":"/"},"name":"web","namespace":"default"},"spec":{"rules":[{"http":{"paths":[{"backend":{"serviceName":"web-svc","servicePort":8000},"path":"/web"}]}}]}}
+
+  nginx.ingress.kubernetes.io/rewrite-target:  /
+Events:
+  Type    Reason  Age   From                      Message
+  ----    ------  ----  ----                      -------
+  Normal  CREATE  74s   nginx-ingress-controller  Ingress default/web
+  Normal  UPDATE  25s   nginx-ingress-controller  Ingress default/web
+
+
+
+curl http://172.17.255.2/web/index.html -Iv
+*   Trying 172.17.255.2...
+* TCP_NODELAY set
+* Connected to 172.17.255.2 (172.17.255.2) port 80 (#0)
+> HEAD /web/index.html HTTP/1.1
+> Host: 172.17.255.2
+> User-Agent: curl/7.58.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+HTTP/1.1 200 OK
+```
+
+## Как запустить проект:
+ - Например, зайти в директорию с манифестами и запустить kubectl
+ kubectl apply -f <file_name>.yaml
+ 
+## Как проверить работоспособность:
+ - перейти по ссылке http://172.17.255.1
+ - перейти по ссылке http://172.17.255.2/web/index.html
+
+## PR checklist:
+ - [X] Выставлен label с номером домашнего задания

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+      - name: default
+        protocol: layer2
+        addresses:
+          - 172.17.255.1-172.17.255.255

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels: 
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector: 
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }
+    

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+#apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector: 
+    matchLabels:
+      app: web
+      
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 100%
+
+  template:
+    metadata:  
+      name: web
+      labels: 
+        app: web
+
+    spec:
+      containers: 
+      - name: web
+        image: doubllew/public1:web-v2
+        volumeMounts:
+        - name: app
+          mountPath: /app
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 20
+
+      initContainers:
+      - name: init-web
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh' ]
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: LoadBalancer

--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,0 +1,171 @@
+# Выполнено ДЗ №
+
+ - [x] Основное ДЗ
+ - [x] Задание со *
+ 
+## В процессе сделано:
+ - Применение StatefulSet
+ - Применили манифест с разворачиванием pod MinIO, созданием PVC и на нем же PV с помощью дефолотногоStorageClass.
+ - Создали Headless Service для внешнего доступа в minio
+```
+kubectl get statefulsets
+NAME    READY   AGE
+minio   1/1     10m
+
+
+kubectl get pods
+NAME      READY   STATUS    RESTARTS   AGE
+minio-0   1/1     Running   0          11m
+
+
+kubectl get pvc
+NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+data-minio-0   Bound    pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669   10Gi       RWO            standard       11m
+
+
+kubectl get pv
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
+pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                11m
+
+
+kubectl describe pvc 
+Name:          data-minio-0
+Namespace:     default
+StorageClass:  standard
+Status:        Bound
+Volume:        pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669
+Labels:        app=minio
+Annotations:   pv.kubernetes.io/bind-completed: yes
+               pv.kubernetes.io/bound-by-controller: yes
+               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/host-path
+Finalizers:    [kubernetes.io/pvc-protection]
+Capacity:      10Gi
+Access Modes:  RWO
+VolumeMode:    Filesystem
+Mounted By:    minio-0
+Events:
+  Type    Reason                 Age   From                         Message
+  ----    ------                 ----  ----                         -------
+  Normal  ProvisioningSucceeded  12m   persistentvolume-controller  Successfully provisioned volume pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669 using kubernetes.io/host-path
+
+
+kubectl describe pv 
+Name:            pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669
+Labels:          <none>
+Annotations:     kubernetes.io/createdby: hostpath-dynamic-provisioner
+                 pv.kubernetes.io/bound-by-controller: yes
+                 pv.kubernetes.io/provisioned-by: kubernetes.io/host-path
+Finalizers:      [kubernetes.io/pv-protection]
+StorageClass:    standard
+Status:          Bound
+Claim:           default/data-minio-0
+Reclaim Policy:  Delete
+Access Modes:    RWO
+VolumeMode:      Filesystem
+Capacity:        10Gi
+Node Affinity:   <none>
+Message:         
+Source:
+    Type:          HostPath (bare host directory volume)
+    Path:          /tmp/hostpath_pv/40242fba-a8e6-47d8-b093-98c24470f5fc
+    HostPathType:  
+Events:            <none>
+```
+
+
+
+#Задание со *
+ - В манифесте StatefulSet логин и пароль передаются в открытом виде, создадим секрет и изменим манифест
+```
+kubectl create secret generic minio-db-secret --from-literal=MINIO_ACCESS_KEY=minio --from-literal=MINIO_SECRET_KEY=minio123
+
+
+kubectl get secrets
+NAME                  TYPE                                  DATA   AGE
+default-token-svgw4   kubernetes.io/service-account-token   3      4h46m
+minio-db-secret       Opaque                                2      47s
+
+
+kubectl get secret minio-db-secret -o yaml
+apiVersion: v1
+data:
+  MINIO_ACCESS_KEY: bWluaW8=
+  MINIO_SECRET_KEY: bWluaW8xMjM=
+kind: Secret
+metadata:
+  creationTimestamp: "2020-01-26T17:46:26Z"
+  name: minio-db-secret
+  namespace: default
+  resourceVersion: "21318"
+  selfLink: /api/v1/namespaces/default/secrets/minio-db-secret
+  uid: 8851fd60-20c6-4aaf-98f7-30c377e5e9b2
+type: Opaque
+```
+ - Добавляем строчку
+```
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-db-secret
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-db-secret
+              key: MINIO_SECRET_KEY
+```
+в блок containers нашего манифеста, запускаем и смотрим
+```
+kubectl apply -f minio-statefulset-secret.yaml 
+statefulset.apps/minio created
+
+
+kubectl get pods
+NAME      READY   STATUS    RESTARTS   AGE
+minio-0   1/1     Running   0          14s
+
+
+kubectl get pvc
+NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+data-minio-0   Bound    pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669   10Gi       RWO            standard       68m
+
+
+kubectl get pv
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
+pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                69m
+
+
+kubectl describe pvc
+Name:          data-minio-0
+Namespace:     default
+StorageClass:  standard
+Status:        Bound
+Volume:        pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669
+Labels:        app=minio
+Annotations:   pv.kubernetes.io/bind-completed: yes
+               pv.kubernetes.io/bound-by-controller: yes
+               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/host-path
+Finalizers:    [kubernetes.io/pvc-protection]
+Capacity:      10Gi
+Access Modes:  RWO
+VolumeMode:    Filesystem
+Mounted By:    minio-0
+Events:        <none>
+```
+
+## Как запустить проект:
+ - Запустить манифест через kubectl
+ kubectl apply -f <file_name>.yaml
+
+
+## Как проверить работоспособность:
+ - kubectl get statefulsets
+ - kubectl get pods
+ - kubectl get pvc
+ - kubectl get pv
+ - kubectl describe pvc
+ 
+
+## PR checklist:
+ - [x] Выставлен label с номером домашнего задания

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/kubernetes-volumes/secrets/minio-statefulset-secret.yaml
+++ b/kubernetes-volumes/secrets/minio-statefulset-secret.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        # use secret from minio-db-secret
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-db-secret
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-db-secret
+              key: MINIO_SECRET_KEY
+#  restartPolicy: Never
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *
 
## В процессе сделано:
 - Применение StatefulSet
 - Применили манифест с разворачиванием pod MinIO, созданием PVC и на нем же PV с помощью дефолотногоStorageClass.
 - Создали Headless Service для внешнего доступа в minio
```
kubectl get statefulsets
NAME    READY   AGE
minio   1/1     10m


kubectl get pods
NAME      READY   STATUS    RESTARTS   AGE
minio-0   1/1     Running   0          11m


kubectl get pvc
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-minio-0   Bound    pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669   10Gi       RWO            standard       11m


kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                11m


kubectl describe pvc 
Name:          data-minio-0
Namespace:     default
StorageClass:  standard
Status:        Bound
Volume:        pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669
Labels:        app=minio
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/host-path
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      10Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    minio-0
Events:
  Type    Reason                 Age   From                         Message
  ----    ------                 ----  ----                         -------
  Normal  ProvisioningSucceeded  12m   persistentvolume-controller  Successfully provisioned volume pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669 using kubernetes.io/host-path


kubectl describe pv 
Name:            pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669
Labels:          <none>
Annotations:     kubernetes.io/createdby: hostpath-dynamic-provisioner
                 pv.kubernetes.io/bound-by-controller: yes
                 pv.kubernetes.io/provisioned-by: kubernetes.io/host-path
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    standard
Status:          Bound
Claim:           default/data-minio-0
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        10Gi
Node Affinity:   <none>
Message:         
Source:
    Type:          HostPath (bare host directory volume)
    Path:          /tmp/hostpath_pv/40242fba-a8e6-47d8-b093-98c24470f5fc
    HostPathType:  
Events:            <none>
```



#Задание со *
 - В манифесте StatefulSet логин и пароль передаются в открытом виде, создадим секрет и изменим манифест
```
kubectl create secret generic minio-db-secret --from-literal=MINIO_ACCESS_KEY=minio --from-literal=MINIO_SECRET_KEY=minio123


kubectl get secrets
NAME                  TYPE                                  DATA   AGE
default-token-svgw4   kubernetes.io/service-account-token   3      4h46m
minio-db-secret       Opaque                                2      47s


kubectl get secret minio-db-secret -o yaml
apiVersion: v1
data:
  MINIO_ACCESS_KEY: bWluaW8=
  MINIO_SECRET_KEY: bWluaW8xMjM=
kind: Secret
metadata:
  creationTimestamp: "2020-01-26T17:46:26Z"
  name: minio-db-secret
  namespace: default
  resourceVersion: "21318"
  selfLink: /api/v1/namespaces/default/secrets/minio-db-secret
  uid: 8851fd60-20c6-4aaf-98f7-30c377e5e9b2
type: Opaque
```
 - Добавляем строчку
```
        env:
        - name: MINIO_ACCESS_KEY
          valueFrom:
            secretKeyRef:
              name: minio-db-secret
              key: MINIO_ACCESS_KEY
        - name: MINIO_SECRET_KEY
          valueFrom:
            secretKeyRef:
              name: minio-db-secret
              key: MINIO_SECRET_KEY
```
в блок containers нашего манифеста, запускаем и смотрим
```
kubectl apply -f minio-statefulset-secret.yaml 
statefulset.apps/minio created


kubectl get pods
NAME      READY   STATUS    RESTARTS   AGE
minio-0   1/1     Running   0          14s


kubectl get pvc
NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-minio-0   Bound    pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669   10Gi       RWO            standard       68m


kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                69m


kubectl describe pvc
Name:          data-minio-0
Namespace:     default
StorageClass:  standard
Status:        Bound
Volume:        pvc-ef7b745c-ce49-4d04-8bc9-49741d3fa669
Labels:        app=minio
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/host-path
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      10Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Mounted By:    minio-0
Events:        <none>
```

## Как запустить проект:
 - Запустить манифест через kubectl
 kubectl apply -f <file_name>.yaml


## Как проверить работоспособность:
 - kubectl get statefulsets
 - kubectl get pods
 - kubectl get pvc
 - kubectl get pv
 - kubectl describe pvc
 

## PR checklist:
 - [x] Выставлен label с номером домашнего задания